### PR TITLE
Cache returned (boolean) 0

### DIFF
--- a/components/MenuHelper.php
+++ b/components/MenuHelper.php
@@ -129,7 +129,7 @@ class MenuHelper
         }
 
         $key = [__METHOD__, $assigned, $root];
-        if ($refresh || $callback !== null || $cache === null || ($result = $cache->get($key) === false)) {
+        if ($refresh || $callback !== null || $cache === null || (($result = $cache->get($key)) === false)) {
             $result = static::normalizeMenu($assigned, $menus, $callback, $root);
             if ($cache !== null && $callback === null) {
                 $cache->set($key, $result, $config->cacheDuration, new TagDependency([


### PR DESCRIPTION
Cache returned (boolean) 0.

($result = $cache->get($key) === false))
replace
(($result = $cache->get($key)) === false))

It has been tested on PHP 5.4.29
