### PR TITLE
Convert user id to string to fix issue of assignment page error about user id (MongoId)

### DIFF
--- a/views/assignment/view.php
+++ b/views/assignment/view.php
@@ -38,7 +38,7 @@ $this->params['breadcrumbs'][] = $this->title;
 <?php
 AdminAsset::register($this);
 $properties = Json::htmlEncode([
-        'userId' => $model->{$idField},
+        'userId' => (string)$model->{$idField},
         'assignUrl' => Url::to(['assign']),
         'searchUrl' => Url::to(['search']),
     ]);


### PR DESCRIPTION
Support MongoDB id field for users.
Before this the id field send with the name "id[$id]". with converting the id of user to string this issue fixed.