### PR TITLE
Added multi app (frontend/backend) support.

### DIFF
--- a/components/Configs.php
+++ b/components/Configs.php
@@ -3,19 +3,19 @@
 namespace mdm\admin\components;
 
 use Yii;
-use yii\db\Connection;
 use yii\caching\Cache;
-use yii\rbac\ManagerInterface;
-use yii\helpers\ArrayHelper;
+use yii\db\Connection;
 use yii\di\Instance;
+use yii\helpers\ArrayHelper;
+use yii\rbac\ManagerInterface;
 
 /**
  * Configs
- * Used for configure some value. To set config you can use [[\yii\base\Application::$params]]
- * 
+ * Used to configure some values. To set config you can use [[\yii\base\Application::$params]]
+ *
  * ```
  * return [
- *     
+ *
  *     'mdm.admin.configs' => [
  *         'db' => 'customDb',
  *         'menuTable' => '{{%admin_menu}}',
@@ -26,9 +26,9 @@ use yii\di\Instance;
  *     ]
  * ];
  * ```
- * 
+ *
  * or use [[\Yii::$container]]
- * 
+ *
  * ```
  * Yii::$container->set('mdm\admin\components\Configs',[
  *     'db' => 'customDb',
@@ -94,9 +94,14 @@ class Configs extends \yii\base\Object
     public $strict = true;
 
     /**
-     * @var array 
+     * @var array
      */
     public $options;
+
+    /**
+     * @var array|false
+     */
+    public $advanced;
 
     /**
      * @var self Instance of self
@@ -106,7 +111,7 @@ class Configs extends \yii\base\Object
         'db' => 'yii\db\Connection',
         'userDb' => 'yii\db\Connection',
         'cache' => 'yii\caching\Cache',
-        'authManager' => 'yii\rbac\ManagerInterface'
+        'authManager' => 'yii\rbac\ManagerInterface',
     ];
 
     /**

--- a/components/Helper.php
+++ b/components/Helper.php
@@ -200,7 +200,7 @@ class Helper
                 }
                 $item['items'] = $subItems;
             }
-            if ($allow) {
+            if ($allow && !($url == '#' && empty($item['items']))) {
                 $result[$i] = $item;
             }
         }

--- a/components/Helper.php
+++ b/components/Helper.php
@@ -2,10 +2,11 @@
 
 namespace mdm\admin\components;
 
+use mdm\admin\models\Route;
 use Yii;
-use yii\web\User;
-use yii\helpers\ArrayHelper;
 use yii\caching\TagDependency;
+use yii\helpers\ArrayHelper;
+use yii\web\User;
 
 /**
  * Description of Helper
@@ -57,7 +58,7 @@ class Helper
                 }
                 if ($cache) {
                     $cache->set($roles, self::$_defaultRoutes, Configs::cacheDuration(), new TagDependency([
-                        'tags' => Configs::CACHE_TAG
+                        'tags' => Configs::CACHE_TAG,
                     ]));
                 }
             }
@@ -87,7 +88,7 @@ class Helper
                 self::$_userRoutes[$userId] = $routes;
                 if ($cache) {
                     $cache->set([__METHOD__, $userId], $routes, Configs::cacheDuration(), new TagDependency([
-                        'tags' => Configs::CACHE_TAG
+                        'tags' => Configs::CACHE_TAG,
                     ]));
                 }
             }
@@ -104,7 +105,7 @@ class Helper
     public static function checkRoute($route, $params = [], $user = null)
     {
         $config = Configs::instance();
-        $r = static::normalizeRoute($route);
+        $r = static::normalizeRoute($route, $config->advanced);
         if ($config->onlyRegisteredRoute && !isset(static::getRegisteredRoutes()[$r])) {
             return true;
         }
@@ -140,18 +141,30 @@ class Helper
         }
     }
 
-    protected static function normalizeRoute($route)
+    /**
+     * Normalize route
+     * @param  string  $route    Plain route string
+     * @param  boolean|array $advanced Array containing the advanced configuration. Defaults to false.
+     * @return string            Normalized route string
+     */
+    protected static function normalizeRoute($route, $advanced = false)
     {
         if ($route === '') {
-            return '/' . Yii::$app->controller->getRoute();
+            $normalized = '/' . Yii::$app->controller->getRoute();
         } elseif (strncmp($route, '/', 1) === 0) {
-            return $route;
+            $normalized = $route;
         } elseif (strpos($route, '/') === false) {
-            return '/' . Yii::$app->controller->getUniqueId() . '/' . $route;
+            $normalized = '/' . Yii::$app->controller->getUniqueId() . '/' . $route;
         } elseif (($mid = Yii::$app->controller->module->getUniqueId()) !== '') {
-            return '/' . $mid . '/' . $route;
+            $normalized = '/' . $mid . '/' . $route;
+        } else {
+            $normalized = '/' . $route;
         }
-        return '/' . $route;
+        // Prefix @app-id to route.
+        if ($advanced) {
+            $normalized = Route::PREFIX_ADVANCED . Yii::$app->id . $normalized;
+        }
+        return $normalized;
     }
 
     /**

--- a/models/Route.php
+++ b/models/Route.php
@@ -145,9 +145,10 @@ class Route extends \yii\base\Object
                 foreach ($r as $route) {
                     $routes[$id . $route] = $id . $route;
                 }
-                // Switch back to original app.
-                Yii::$app = $yiiApp;
             }
+            // Switch back to original app.
+            Yii::$app = $yiiApp;
+            unset($yiiApp);
         } else {
             // Use basic route scheme.
             // Set basic route prefix

--- a/models/Route.php
+++ b/models/Route.php
@@ -20,6 +20,11 @@ class Route extends \yii\base\Object
 {
     const CACHE_TAG = 'mdm.admin.route';
 
+    const PREFIX_ADVANCED = '@';
+    const PREFIX_BASIC = '/';
+
+    private $_routePrefix;
+
     /**
      * Assign or remove items
      * @param array $routes
@@ -31,7 +36,7 @@ class Route extends \yii\base\Object
         foreach ($routes as $route) {
             try {
                 $r = explode('&', $route);
-                $item = $manager->createPermission('/' . trim($route, '/'));
+                $item = $manager->createPermission($this->getPermissionName($route));
                 if (count($r) > 1) {
                     $action = '/' . trim($r[0], '/');
                     if (($itemAction = $manager->getPermission($action)) === null) {
@@ -67,7 +72,7 @@ class Route extends \yii\base\Object
         $manager = Configs::authManager();
         foreach ($routes as $route) {
             try {
-                $item = $manager->createPermission('/' . trim($route, '/'));
+                $item = $manager->createPermission($this->getPermissionName($route));
                 $manager->remove($item);
             } catch (Exception $exc) {
                 Yii::error($exc->getMessage(), __METHOD__);
@@ -77,16 +82,82 @@ class Route extends \yii\base\Object
     }
 
     /**
+     * Returns route prefix depending on the configuration.
+     * @return string Route prefix
+     */
+    public function getRoutePrefix()
+    {
+        if (!$this->_routePrefix) {
+            $this->_routePrefix = Configs::instance()->advanced ? self::PREFIX_ADVANCED : self::PREFIX_BASIC;
+        }
+        return $this->_routePrefix;
+    }
+
+    /**
+     * Returns the correct permission name depending on the configuration.
+     * @param  string $route Route
+     * @return string        Permission name
+     */
+    public function getPermissionName($route)
+    {
+        if (self::PREFIX_BASIC == $this->routePrefix) {
+            return self::PREFIX_BASIC . trim($route, self::PREFIX_BASIC);
+        } else {
+            return self::PREFIX_ADVANCED . ltrim(trim($route, self::PREFIX_BASIC), self::PREFIX_ADVANCED);
+        }
+    }
+
+    /**
      * Get available and assigned routes
      * @return array
      */
     public function getRoutes()
     {
         $manager = Configs::authManager();
-        $routes = $this->getAppRoutes();
+        // Get advanced configuration
+        $advanced = Configs::instance()->advanced;
+        if ($advanced) {
+            // Use advanced route scheme.
+            // Set advanced route prefix.
+            $this->_routePrefix = self::PREFIX_ADVANCED;
+            // Create empty routes array.
+            $routes = [];
+            // Save original app.
+            $yiiApp = Yii::$app;
+            // Step through each configured application
+            foreach ($advanced as $id => $configPaths) {
+                // Force correct id string.
+                $id = $this->routePrefix . ltrim(trim($id), $this->routePrefix);
+                // Create empty config array.
+                $config = [];
+                // Assemble configuration for current app.
+                foreach ($configPaths as $configPath) {
+                    // Merge every new configuration with the old config array.
+                    $config = yii\helpers\ArrayHelper::merge($config, require (Yii::getAlias($configPath)));
+                }
+                // Create new app using the config array.
+                $app = new yii\web\Application($config);
+                // Get all the routes of the newly created app.
+                $r = $this->getAppRoutes($app);
+                // Dump new app
+                unset($app);
+                // Prepend the app id to all routes.
+                foreach ($r as $route) {
+                    $routes[$id . $route] = $id . $route;
+                }
+                // Switch back to original app.
+                Yii::$app = $yiiApp;
+            }
+        } else {
+            // Use basic route scheme.
+            // Set basic route prefix
+            $this->_routePrefix = self::PREFIX_BASIC;
+            // Get basic app routes.
+            $routes = $this->getAppRoutes();
+        }
         $exists = [];
         foreach (array_keys($manager->getPermissions()) as $name) {
-            if ($name[0] !== '/') {
+            if ($name[0] !== $this->routePrefix) {
                 continue;
             }
             $exists[] = $name;

--- a/models/Route.php
+++ b/models/Route.php
@@ -136,6 +136,7 @@ class Route extends \yii\base\Object
                     $config = yii\helpers\ArrayHelper::merge($config, require (Yii::getAlias($configPath)));
                 }
                 // Create new app using the config array.
+                unset($config['bootstrap']);
                 $app = new yii\web\Application($config);
                 // Get all the routes of the newly created app.
                 $r = $this->getAppRoutes($app);

--- a/models/Route.php
+++ b/models/Route.php
@@ -181,7 +181,7 @@ class Route extends \yii\base\Object
         } elseif (is_string($module)) {
             $module = Yii::$app->getModule($module);
         }
-        $key = [__METHOD__, $module->getUniqueId()];
+        $key = [__METHOD__, Yii::$app->id, $module->getUniqueId()];
         $cache = Configs::instance()->cache;
         if ($cache === null || ($result = $cache->get($key)) === false) {
             $result = [];


### PR DESCRIPTION
Since i would like this extension to work with Yii2s advanced template, i made some modifications.
Basically, if you do not configure anything, this PR still works as the original with support for the basic application template.
You can however configure multiple apps according to your individual (or default advanced) template. For this feature to work i use the Configs->advanced property.
For example, the following array in @common/config/params.php configures this extension to work with the Yii2 advanced template.

```
'mdm.admin.configs' => [
        'advanced' => [
            'app-backend' => [
                '@common/config/main.php',
                '@common/config/main-local.php',
                '@backend/config/main.php',
                '@backend/config/main-local.php',
            ],
            'app-frontend' => [
                '@common/config/main.php',
                '@common/config/main-local.php',
                '@frontend/config/main.php',
                '@frontend/config/main-local.php',
            ],
        ],
    ],
```

**advanced** needs to be an array. Each item consists of
**key**: (_string_) application id as defined in @{app}/config/main.php (**app-backend** and **app-frontend** in this configuration) and
**value**: (_array_) of configuration files used by the respective application. I use the Yii::getAlias() method, so using aliases works fine.

Now you can set up the module part of this extension only in the backend of your application. There you can access all application wide routes. So you are able, for example, to grant User1 access to the a specific action or controller in the frontend (_@app-frontend/demo/some-action_), while giving User2 access to the same action or controller in the backend (_@app-backend/demo/some-action_).
The advanced routes contain the application id as prefix, e.g. **@app-backend/admin/*** or **@app-frontend/***


