### PR TITLE
Add additional group to avoid crash on non-exists item

### DIFF
--- a/views/assignment/_script.js
+++ b/views/assignment/_script.js
@@ -1,4 +1,5 @@
 $('i.glyphicon-refresh-animate').hide();
+
 function updateItems(r) {
     _opts.items.available = r.available;
     _opts.items.assigned = r.assigned;
@@ -34,9 +35,13 @@ function search(target) {
     var groups = {
         role: [$('<optgroup label="Roles">'), false],
         permission: [$('<optgroup label="Permission">'), false],
+        lost: [$('<optgroup style="color: brown" label="LostItems">'), false],
     };
     $.each(_opts.items[target], function (name, group) {
         if (name.indexOf(q) >= 0) {
+            if (!group) {
+                group = 'lost';
+            }
             $('<option>').text(name).val(name).appendTo(groups[group][0]);
             groups[group][1] = true;
         }


### PR DESCRIPTION
For this case:
1. we have permission in authManager
2. we assign this permission to user 1
3. we delete record related to this permission from db
4. we wish to see user 1 permission `admin/assignment/view?id=1`
5. !js crash: the right panel is empty now! we can see LostItems group (brown colored)