### PR TITLE
Remove display character limit on int data types

### DIFF
--- a/migrations/schema-mssql.sql
+++ b/migrations/schema-mssql.sql
@@ -12,9 +12,9 @@ create table [menu]
 (
     [id] int IDENTITY PRIMARY KEY,
     [name] varchar(128),
-    [parent] int(11),
+    [parent] int,
     [route] varchar(256),
-    [order] int(11),
+    [order] int,
     [data]   text,
     foreign key (parent) references [menu]([id])  ON DELETE SET NULL ON UPDATE CASCADE
 );


### PR DESCRIPTION
MSSQL does not support the pure mysql int declaration with a display limit specification.