### PR TITLE
Update Configs.php

### DIFF
--- a/classes/Configs.php
+++ b/classes/Configs.php
@@ -6,7 +6,7 @@ use Yii;
 use yii\db\Connection;
 use yii\caching\Cache;
 use yii\helpers\ArrayHelper;
-use yii\base\Object;
+use yii\base\BaseObject;
 
 /**
  * Configs
@@ -34,7 +34,7 @@ use yii\base\Object;
  * @author Misbahul D Munir <misbahuldmunir@gmail.com>
  * @since 1.0
  */
-class Configs extends Object
+class Configs extends BaseObject
 {
     /**
      * @var array


### PR DESCRIPTION
Fix PHP 7 Fatal error:  Cannot use yii\base\Object as Object because 'Object' is a special class name
and Updating yiisoft/yii2 (2.0.12 => 2.0.16.1)