### PR TITLE
Do not show routes on both Permissions list and Permission assignment

### DIFF
--- a/models/AuthItem.php
+++ b/models/AuthItem.php
@@ -246,6 +246,7 @@ class AuthItem extends Model
     public function getItems()
     {
         $manager = Configs::authManager();
+        $advanced = Configs::instance()->advanced;
         $available = [];
         if ($this->type == Item::TYPE_ROLE) {
             foreach (array_keys($manager->getRoles()) as $name) {
@@ -254,11 +255,12 @@ class AuthItem extends Model
         }
         foreach (array_keys($manager->getPermissions()) as $name) {
             $available[$name] = $name[0] == '/' ? 'route' : 'permission';
+            $available[$name] = $name[0] == '/' || $advanced && $name[0] == '@' ? 'route' : 'permission';
         }
-
         $assigned = [];
         foreach ($manager->getChildren($this->_item->name) as $item) {
             $assigned[$item->name] = $item->type == 1 ? 'role' : ($item->name[0] == '/' ? 'route' : 'permission');
+            $assigned[$item->name] = $item->type == 1 ? 'role' : ($item->name[0] == '/' || $advanced && $item->name[0] == '@' ? 'route' : 'permission');
             unset($available[$item->name]);
         }
         unset($available[$this->name]);

--- a/models/searchs/AuthItem.php
+++ b/models/searchs/AuthItem.php
@@ -2,15 +2,15 @@
 
 namespace mdm\admin\models\searchs;
 
+use mdm\admin\components\Configs;
 use Yii;
 use yii\base\Model;
 use yii\data\ArrayDataProvider;
-use mdm\admin\components\Configs;
 use yii\rbac\Item;
 
 /**
  * AuthItemSearch represents the model behind the search form about AuthItem.
- * 
+ *
  * @author Misbahul D Munir <misbahuldmunir@gmail.com>
  * @since 1.0
  */
@@ -62,8 +62,9 @@ class AuthItem extends Model
         if ($this->type == Item::TYPE_ROLE) {
             $items = $authManager->getRoles();
         } else {
-            $items = array_filter($authManager->getPermissions(), function($item) {
-                return $this->type == Item::TYPE_PERMISSION xor strncmp($item->name, '/', 1) === 0;
+            $items = array_filter($authManager->getPermissions(), function ($item) {
+                $advanced = Configs::instance()->advanced;
+                return $this->type == Item::TYPE_PERMISSION xor strncmp($item->name, '/', 1) === 0 xor $advanced && strncmp($item->name, '@', 1) === 0;
             });
         }
         $this->load($params);


### PR DESCRIPTION
Do not show routes on both Permissions list and Permission assignment  when advanced config is enabled