### PR TITLE
Update AuthItem for support PHP 8.1

### DIFF
--- a/models/searchs/AuthItem.php
+++ b/models/searchs/AuthItem.php
@@ -30,6 +30,7 @@ class AuthItem extends Model
     public function rules()
     {
         return [
+            [['name', 'ruleName', 'description'], 'trim'],
             [['name', 'ruleName', 'description'], 'safe'],
             [['type'], 'integer'],
         ];


### PR DESCRIPTION
Fixed bug in Permission Page and Role Page

PHP Deprecated Warning – [yii\base\ErrorException](https://www.yiiframework.com/doc-2.0/yii-base-errorexception.html)
trim(): Passing null to parameter #1 ($string) of type string is deprecated