### PR TITLE
Fix php8.1 null parameter

### DIFF
--- a/components/AccessControl.php
+++ b/components/AccessControl.php
@@ -108,7 +108,7 @@ class AccessControl extends \yii\base\ActionFilter
                 }else if(is_string($user->loginUrl)){
                     $loginUrl = $user->loginUrl;
                 }
-                if(!is_null($loginUrl) && trim($loginUrl,'/') === $uniqueId)
+                if(!is_null($loginUrl) && trim((string)$loginUrl,'/') === $uniqueId)
                 {
                     return false;
                 }
@@ -127,7 +127,7 @@ class AccessControl extends \yii\base\ActionFilter
 
         foreach ($this->allowActions as $route) {
             if (substr($route, -1) === '*') {
-                $route = rtrim($route, "*");
+                $route = rtrim(string)$route, "*");
                 if ($route === '' || strpos($id, $route) === 0) {
                     return false;
                 }

--- a/controllers/RouteController.php
+++ b/controllers/RouteController.php
@@ -48,7 +48,7 @@ class RouteController extends Controller
     {
         Yii::$app->getResponse()->format = 'json';
         $routes = Yii::$app->getRequest()->post('route', '');
-        $routes = preg_split('/\s*,\s*/', trim($routes), -1, PREG_SPLIT_NO_EMPTY);
+        $routes = preg_split('/\s*,\s*/', trim((string)$routes), -1, PREG_SPLIT_NO_EMPTY);
         $model = new Route();
         $model->addNew($routes);
         return $model->getRoutes();

--- a/models/Route.php
+++ b/models/Route.php
@@ -38,7 +38,7 @@ class Route extends \mdm\admin\BaseObject
                 $r = explode('&', $route);
                 $item = $manager->createPermission($this->getPermissionName($route));
                 if (count($r) > 1) {
-                    $action = '/' . trim($r[0], '/');
+                    $action = '/' . trim((string)$r[0], '/');
                     if (($itemAction = $manager->getPermission($action)) === null) {
                         $itemAction = $manager->createPermission($action);
                         $manager->add($itemAction);
@@ -101,9 +101,9 @@ class Route extends \mdm\admin\BaseObject
     public function getPermissionName($route)
     {
         if (self::PREFIX_BASIC == $this->routePrefix) {
-            return self::PREFIX_BASIC . trim($route, self::PREFIX_BASIC);
+            return self::PREFIX_BASIC . trim((string)$route, self::PREFIX_BASIC);
         } else {
-            return self::PREFIX_ADVANCED . ltrim(trim($route, self::PREFIX_BASIC), self::PREFIX_ADVANCED);
+            return self::PREFIX_ADVANCED . ltrim((string)trim((string)$route, self::PREFIX_BASIC), self::PREFIX_ADVANCED);
         }
     }
 
@@ -127,7 +127,7 @@ class Route extends \mdm\admin\BaseObject
             // Step through each configured application
             foreach ($advanced as $id => $configPaths) {
                 // Force correct id string.
-                $id = $this->routePrefix . ltrim(trim($id), $this->routePrefix);
+                $id = $this->routePrefix . ltrim((string)trim((string)$id), $this->routePrefix);
                 // Create empty config array.
                 $config = [];
                 // Assemble configuration for current app.
@@ -217,9 +217,9 @@ class Route extends \mdm\admin\BaseObject
                 $this->getControllerActions($type, $id, $module, $result);
             }
 
-            $namespace = trim($module->controllerNamespace, '\\') . '\\';
+            $namespace = trim((string)$module->controllerNamespace, '\\') . '\\';
             $this->getControllerFiles($module, $namespace, '', $result);
-            $all = '/' . ltrim($module->uniqueId . '/*', '/');
+            $all = '/' . ltrim((string)$module->uniqueId . '/*', '/');
             $result[$all] = $all;
         } catch (\Exception $exc) {
             Yii::error($exc->getMessage(), __METHOD__);
@@ -253,7 +253,7 @@ class Route extends \mdm\admin\BaseObject
                 } elseif (strcmp(substr($file, -14), 'Controller.php') === 0) {
                     $baseName = substr(basename($file), 0, -14);
                     $name = strtolower(preg_replace('/(?<![A-Z])[A-Z]/', ' \0', $baseName));
-                    $id = ltrim(str_replace(' ', '-', $name), '-');
+                    $id = ltrim((string)str_replace(' ', '-', $name), '-');
                     $className = $namespace . $baseName . 'Controller';
                     if (strpos($className, '-') === false && class_exists($className) && is_subclass_of($className, 'yii\base\Controller')) {
                         $this->getControllerActions($className, $prefix . $id, $module, $result);
@@ -308,7 +308,7 @@ class Route extends \mdm\admin\BaseObject
                 $name = $method->getName();
                 if ($method->isPublic() && !$method->isStatic() && strpos($name, 'action') === 0 && $name !== 'actions') {
                     $name = strtolower(preg_replace('/(?<![A-Z])[A-Z]/', ' \0', substr($name, 6)));
-                    $id = $prefix . ltrim(str_replace(' ', '-', $name), '-');
+                    $id = $prefix . ltrim((string)str_replace(' ', '-', $name), '-');
                     $result[$id] = $id;
                 }
             }

--- a/models/searchs/AuthItem.php
+++ b/models/searchs/AuthItem.php
@@ -76,8 +76,8 @@ class AuthItem extends Model
         $this->load($params);
         if ($this->validate()) {
 
-            $search = mb_strtolower(trim($this->name));
-            $desc = mb_strtolower(trim($this->description));
+            $search = mb_strtolower(trim((string)$this->name));
+            $desc = mb_strtolower(trim((string)$this->description));
             $ruleName = $this->ruleName;
             foreach ($items as $name => $item) {
                 $f = (empty($search) || mb_strpos(mb_strtolower($item->name), $search) !== false) &&

--- a/models/searchs/BizRule.php
+++ b/models/searchs/BizRule.php
@@ -49,7 +49,7 @@ class BizRule extends Model
         /* @var \yii\rbac\Manager $authManager */
         $authManager = Configs::authManager();
         $models = [];
-        $included = !($this->load($params) && $this->validate() && trim($this->name) !== '');
+        $included = !($this->load($params) && $this->validate() && trim((string)$this->name) !== '');
         foreach ($authManager->getRules() as $name => $item) {
             if ($name != RouteRule::RULE_NAME && ($included || stripos($item->name, $this->name) !== false)) {
                 $models[$name] = new MBizRule($item);

--- a/views/default/index.php
+++ b/views/default/index.php
@@ -33,7 +33,7 @@ $body = preg_replace_callback('/\]\((.*?)\)/', function($matches) use($baseDir) 
     $link = $matches[1];
     if (strpos($link, '://') === false) {
         if ($link[0] == '/') {
-            $link = Url::current(['page' => ltrim($link, '/')], true);
+            $link = Url::current(['page' => ltrim((string)$link, '/')], true);
         } else {
             $link = Url::current(['page' => $baseDir . $link], true);
         }

--- a/views/layouts/left-menu.php
+++ b/views/layouts/left-menu.php
@@ -9,7 +9,7 @@ $controller = $this->context;
 $menus = $controller->module->menus;
 $route = $controller->route;
 foreach ($menus as $i => $menu) {
-    $menus[$i]['active'] = strpos($route, trim($menu['url'][0], '/')) === 0;
+    $menus[$i]['active'] = strpos($route, trim((string)$menu['url'][0], '/')) === 0;
 }
 $this->params['nav-items'] = $menus;
 ?>

--- a/views/layouts/right-menu.php
+++ b/views/layouts/right-menu.php
@@ -9,7 +9,7 @@ $controller = $this->context;
 $menus = $controller->module->menus;
 $route = $controller->route;
 foreach ($menus as $i => $menu) {
-    $menus[$i]['active'] = strpos($route, trim($menu['url'][0], '/')) === 0;
+    $menus[$i]['active'] = strpos($route, trim((string)$menu['url'][0], '/')) === 0;
 }
 $this->params['nav-items'] = $menus;
 ?>

--- a/views/layouts/top-menu.php
+++ b/views/layouts/top-menu.php
@@ -6,7 +6,7 @@ $controller = $this->context;
 $menus = $controller->module->menus;
 $route = $controller->route;
 foreach ($menus as $i => $menu) {
-    $menus[$i]['active'] = strpos($route, trim($menu['url'][0], '/')) === 0;
+    $menus[$i]['active'] = strpos($route, trim((string)$menu['url'][0], '/')) === 0;
 }
 $this->params['nav-items'] = $menus;
 $this->params['top-menu'] = true;


### PR DESCRIPTION
### PHP Deprecated

Passing null to parameter deprecated on **PHP 8.1** 

`PHP Deprecated : trim() : Passing null to parameter #1 ($string) of type string is deprecated.`

This happens when the default value for the variable is `null`.

### Possible Solution
We can simply cast the variable to string to fix the issue.

```diff
-trim($v);
+trim((string) $v);

-ltrim($v);
+ltrim((string) $v);

-rtrim($v);
+rtrim((string) $v);
```

This solution also used in symfony. Please see [this](https://github.com/symfony/symfony/pull/45181).